### PR TITLE
organize http api methods and interfaces

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,7 +129,7 @@ switch (command) {
 	}
 	case 'setname': {
 		const previousname = await api.getDeviceName();
-		await api.setDeviceName(positionals[1]);
+		await api.setDeviceName({ name: positionals[1] });
 		const newname = await api.getDeviceName();
 		// biome-ignore lint/style/useTemplate: <explanation>
 		console.log(previousname.name + ' has been set to ' + newname.name);


### PR DESCRIPTION
I am trying to make sure we put all of the methods and interfaces in the order of the docs at https://xled-docs.readthedocs.io/en/latest/rest_api.html#.  This also adds a couple of missing APIs for #11 